### PR TITLE
explicitly handle redis connection error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,12 @@ function seenreq(options) {
 	}
     
 	this.repo = new Repo(options);
-    
+	
+	//handle redis error
+	if(options.repo === 'redis') {
+		this.repo.redis.once('error', (err)=> {throw new Error(err)})
+	}
+	
 	if(!options.normalizer){
 		Normalizers.push(require('./lib/normalizer/default.js'));
 	}else{


### PR DESCRIPTION
ioredis will eat the error if the connection to the redis host is refused. This PR will throw a connection error when the connection is rejected.